### PR TITLE
Update remote_cron_dump.sh

### DIFF
--- a/remote_cron_dump.sh
+++ b/remote_cron_dump.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
-report=server_cron_report_name.txt
-for servers in $(echo SERVER_ARRAY{1..4}.DOMAIN); 
+report=shib_cron_report.txt; 
+for servers in $(echo $1); 
 do 
-  echo $servers >> $report; 
-  ssh $servers 'for users in $(ls /home/); do echo "$users: $(sudo crontab -l -u $users > /dev/null 2>&1 && sudo crontab -l -u $users)"; done' >> $report; 
+	echo $servers >> $report; 
+	ssh -t $servers '
+	for users in $(cut -d ":" -f1 /etc/passwd); 
+	do 
+		echo "$users: $(sudo crontab -l -u $users > /dev/null 2>&1 && sudo crontab -l -u $users)"; 
+	done
+       ' >> $report; 
 done


### PR DESCRIPTION
Updated to crawl /etc/passwd for accounts which may not have shells in /home. 
Also made to take $1 environment var instead of hard-coded server names.